### PR TITLE
Added Facette run directory

### DIFF
--- a/nagios/MotechHealth/libexec/motechAlertParser.py
+++ b/nagios/MotechHealth/libexec/motechAlertParser.py
@@ -68,7 +68,7 @@ if (data['metadata']['totalCount'] > 0):
           if ((pr['data'][count]['alertType']) =='LOW'):
         	  Low_Count = Low_Count + 1
           datetime=time.strftime('%d-%b-%y %H:%M:%S', time.localtime((pr['data'][count]['creationDate'])/1000))
-          alert=datetime+","+str((pr['data'][count]['id']))+","+str((pr['data'][count]['priority']))+","+(pr['data'][count]['alertType'])+","+(pr['data'][count]['name'])+","+(pr['data'][count]['description'])
+          alert=datetime+","+str((pr['data'][count]['id']))+","+str((pr['data'][count]['priority']))+","+str((pr['data'][count]['alertType']))+","+str((pr['data'][count]['name']))+","+str((pr['data'][count]['description']))
           f.write(alert)
           f.write('\n')
 

--- a/nagios/MotechHealth/libexec/motechHourAlert.py
+++ b/nagios/MotechHealth/libexec/motechHourAlert.py
@@ -78,7 +78,7 @@ if (data['metadata']['totalCount'] > 0):
           if ((pr['data'][count]['alertType']) =='LOW'):
         	  Low_Count = Low_Count + 1
           datetime = time.strftime('%d-%b-%y %H:%M:%S', time.localtime((pr['data'][count]['creationDate'])/1000))
-          alert = datetime+","+str((pr['data'][count]['id']))+","+(pr['data'][count]['alertType'])+","+(pr['data'][count]['name'])+","+(pr['data'][count]['description'])
+          alert = datetime+","+str((pr['data'][count]['id']))+","+str((pr['data'][count]['alertType']))+","+str((pr['data'][count]['name']))+","+str((pr['data'][count]['description']))
           f.write(alert)
           f.write('\n')
   if( Fresh_Alert > 0):

--- a/roles/collectd/tasks/facette.yml
+++ b/roles/collectd/tasks/facette.yml
@@ -90,6 +90,15 @@
   notify:
     - Restart Facette
 
+- name: "Create Facette Daemon path"
+  file: >
+    path=/var/run/facette
+    state=directory
+    owner=facette
+    group=facette
+  notify:
+    - Restart Facette
+
 - name: Add Facette port in firewall
   shell:
         firewall-cmd --zone=public --add-port={{ facette_port }}/tcp --permanent

--- a/roles/web/templates/flw.properties.j2
+++ b/roles/web/templates/flw.properties.j2
@@ -1,4 +1,4 @@
 #Thu Nov 12 09:35:12 IST 2015
 flw.weeks_to_keep_invalid_flws=6
-flw.purge_invalid_flw_start_time=04\:00
+flw.purge_invalid_flw_start_time=00\:30
 flw.purge_invalid_flw_sec_interval=86400

--- a/roles/web/templates/kilkari.properties.j2
+++ b/roles/web/templates/kilkari.properties.j2
@@ -1,4 +1,4 @@
 #Mon Jul 27 15:16:03 IST 2015
 kilkari.weeks_to_keep_closed_subscriptions=6
 kilkari.purge_closed_subscriptions_sec_interval=86400
-kilkari.purge_closed_subscriptions_start_time=06\:00
+kilkari.purge_closed_subscriptions_start_time=03\:30


### PR DESCRIPTION
Update 1 Factee
Facette was not able to start on startup or with service and complained 
"Error: unable to create pid file `/var/run/facette/facette.pid'"
facette runs with user facette which didn't had permission to create directory in /var/run.. Factte playbook is updated to create directory in /var/run/factte with ownership to facette user

Update 2  NMSSUPPORT-11
NMS Kilkari purging time conflicted with OBD file generation. 

Update 3: NIP-282
Updated Motech Hour alert script removal of compilation errors
